### PR TITLE
Insert logo into animated beam

### DIFF
--- a/components/featureSection/animatedBeam.tsx
+++ b/components/featureSection/animatedBeam.tsx
@@ -126,7 +126,7 @@ const Icons = {
   herewegoal: ({ className }: { className?: string } = {}) => (
     <div className={cn('flex items-center justify-center w-full h-full', className)}>
       <Image
-        src="/herewegoal_landing_new.png"
+        src="/herewegoal_logo.png"
         alt="HereWeGoal Logo"
         width={48}
         height={48}


### PR DESCRIPTION
Correct the HereWeGoal logo in the animated beam to use `herewegoal_logo.png`.